### PR TITLE
upgrade to `debian:bookworm-slim`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 MAINTAINER Philippe Le Van (@plv on twitter)
 


### PR DESCRIPTION
this upgrades the tagged base image of the `Dockerfile` to `debian:bookworm-slim`